### PR TITLE
Option to give coil custom coordinates

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -11,6 +11,8 @@ namespace LethalTubeRemoval
 {
     public class Config
     {
+        private const string chargingcoil = "Charging Coil Reposition:";
+
         private const string inside = "Inside Ship:";
 
         private const string outside = "Outside Ship:";
@@ -18,6 +20,18 @@ namespace LethalTubeRemoval
         private const string storeItems = "Store Items:";
 
         private const string misc = "Misc Modes:";
+
+
+
+        //Custom Coil Coords
+        public static ConfigEntry<bool> moveCoil;
+        public static ConfigEntry<float> xCordCoil;
+        public static ConfigEntry<float> yCordCoil;
+        public static ConfigEntry<float> zCordCoil;
+
+        public static ConfigEntry<float> xRotCoil;
+        public static ConfigEntry<float> yRotCoil;
+        public static ConfigEntry<float> zRotCoil;
 
         //Store Items
         public static ConfigEntry<bool> deleteTeleporterCord;
@@ -63,14 +77,80 @@ namespace LethalTubeRemoval
 
         public Config(ConfigFile cfg)
         {
+
+
+            //Custom Coords
+
+            moveCoil = cfg.Bind(
+             chargingcoil,
+             "Move Coil",
+             false,
+             "Allows the custom coordinates to be set"
+         ); var coilMoveToggle = new BoolCheckBoxConfigItem(moveCoil, requiresRestart: false);
+            LethalConfigManager.AddConfigItem(coilMoveToggle);
+
+            xCordCoil = cfg.Bind(
+             chargingcoil,
+             "X-Coordinate",
+             -0.343f,
+             "Sets X-coordinate of Charging Coil"
+         );
+            var coilX = new FloatInputFieldConfigItem(xCordCoil, requiresRestart: false);
+            LethalConfigManager.AddConfigItem(coilX);
+
+            yCordCoil = cfg.Bind(
+             chargingcoil,
+             "Y-Coordinate",
+             1.2561f,
+             "Sets Y-coordinate of Charging Coil"
+         );
+            var coilY = new FloatInputFieldConfigItem(yCordCoil, requiresRestart: false);
+            LethalConfigManager.AddConfigItem(coilY);
+
+            zCordCoil = cfg.Bind(
+             chargingcoil,
+             "Z-Coordinate",
+             -4.802f,
+             "Sets Z-coordinate of Charging Coil"
+         );
+            var coilZ = new FloatInputFieldConfigItem(zCordCoil, requiresRestart: false);
+            LethalConfigManager.AddConfigItem(coilZ);
+
+            xRotCoil = cfg.Bind(
+             chargingcoil,
+             "X-Rotation",
+             270f,
+             "Sets X-Rotation of Charging Coil"
+         );
+            var rotX = new FloatInputFieldConfigItem(xRotCoil, requiresRestart: false);
+            LethalConfigManager.AddConfigItem(rotX);
+
+            yRotCoil = cfg.Bind(
+             chargingcoil,
+             "Y-Rotation",
+             0.0009f,
+             "Sets Y-Rotation of Charging Coil"
+         );
+            var rotY = new FloatInputFieldConfigItem(yRotCoil, requiresRestart: false);
+            LethalConfigManager.AddConfigItem(rotY);
+
+            zRotCoil = cfg.Bind(
+             chargingcoil,
+             "Z-Rotation",
+             0f,
+             "Sets Z-Rotation of Charging Coil"
+         );
+            var rotZ = new FloatInputFieldConfigItem(zRotCoil, requiresRestart: false);
+            LethalConfigManager.AddConfigItem(rotZ);
+
             //Inside Ship
 
             deleteTube = cfg.Bind(                                  //sets initial LethalConfig values
-               inside,                                           //type of change
-               "Tube",                                              //Name in the UI
-               true,                                                //default value
-               "Deletes the tube on the floor"                      //Description for UI
-           );
+                   inside,                                           //type of change
+                   "Tube",                                              //Name in the UI
+                   true,                                                //default value
+                   "Deletes the tube on the floor"                      //Description for UI
+               );
             var tubeToggle = new BoolCheckBoxConfigItem(deleteTube, requiresRestart: false);    //sets as checkbox for bool, sets restart flag as false as these changes do not require a restart of the game
             LethalConfigManager.AddConfigItem(tubeToggle);
 

--- a/Patches/TubeRemovalPatch.cs
+++ b/Patches/TubeRemovalPatch.cs
@@ -172,10 +172,25 @@ namespace LethalTubeRemoval.Patches
                 GameObject.Destroy(areaLight3);
                 GameObject.Destroy(hangingLamp1);
                 GameObject.Destroy(hangingLamp3);
-
             }
-
         }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(StartOfRound), "Update")]
+        public static void CustomCoords()
+        { 
+            //for custom charging coil coordinates
+            if (Config.moveCoil.Value)
+            {
+                GameObject chargingCoil = GameObject.Find("Environment/HangarShip/ShipModels2b/ChargeStation");
+                UnityEngine.Vector3 chargeLocalPos = new Vector3(xCordCoil.Value, yCordCoil.Value, zCordCoil.Value);
+                UnityEngine.Vector3 chargeLocalRotation = new Vector3(xRotCoil.Value, yRotCoil.Value, zRotCoil.Value);
+
+                chargingCoil.transform.localPosition = chargeLocalPos;
+                chargingCoil.transform.eulerAngles = chargeLocalRotation;
+            }
+        }
+
 
         [HarmonyPostfix]
         [HarmonyPatch(typeof(ShipTeleporter), "Awake")]

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -21,7 +21,7 @@ namespace LethalTubeRemoval
     {
         private const string modGUID = "Hamster.LethalTubeRemoval";
         private const string modName = "Lethal Tube Removal";
-        private const string modVersion = "1.4.2";
+        private const string modVersion = "1.4.4";
 
         public static new Config MyConfig { get; internal set; }
 


### PR DESCRIPTION
The option to give custom coordinates to only the charging coil has been added. For reasons I've not quite uncovered, there are a few quirks when feeding the values. Such as when setting the y-axis of rotation to 270, it will actually set it to 180, but setting it to 180 sets it to 0. Perhaps someone more knowledgeable than I in Unity can explain what's going on there, but I've yet to figure it out. 

The coordinates update the position of the charging station in real-time, so you can change them from within LethalConfig at the **_PAUSE_** menu. I have moved this option to the top of the list so it is more convenient to test with it until you get it right.

The default settings in the config are the default coordinates for the charging station. I have attached below the settings I used to get the station to the other side of the ship and flip it around. You can use this as a starting point to get an idea of how to move it. This position is local to your ship, so it will stay in the same spot on the wall as you fly in and out of orbit.

If you find a spot you like, I would advise making a note of the coordinates and rotation in case they are reset.

![Lethal Company Screenshot 2024 03 15 - 21 45 58 20](https://github.com/d-rafferty/lethal-tube-removal/assets/90558421/aaaddec5-49a4-4451-8c1f-3265c481f748)
![Lethal Company Screenshot 2024 03 15 - 21 46 09 62](https://github.com/d-rafferty/lethal-tube-removal/assets/90558421/20d94053-728a-40fd-b913-f17532e9b49b)
