### PR TITLE
[FIX] Remove redundant using statements & cleanup code

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -1,533 +1,524 @@
 ﻿using BepInEx.Configuration;
-using LethalConfig.ConfigItems;
 using LethalConfig;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using LethalConfig.ConfigItems;
 
-namespace LethalTubeRemoval
+namespace LethalTubeRemoval;
+
+public class Config
 {
-    public class Config
+    private const string terminalmove = "Terminal Reposition";
+
+    private const string chargingcoil = "Charging Coil Reposition";
+
+    private const string inside = "Inside Ship";
+
+    private const string outside = "Outside Ship";
+
+    private const string storeItems = "Store Items";
+
+    private const string misc = "Misc Modes";
+
+    //Custom Terminal Coords
+    public static ConfigEntry<bool> customTerminal;
+    public static ConfigEntry<float> xCordTerm;
+    public static ConfigEntry<float> yCordTerm;
+    public static ConfigEntry<float> zCordTerm;
+
+    public static ConfigEntry<float> xRotTerm;
+    public static ConfigEntry<float> yRotTerm;
+    public static ConfigEntry<float> zRotTerm;
+
+    //Custom Coil Coords
+    public static ConfigEntry<bool> moveCoil;
+    public static ConfigEntry<float> xCordCoil;
+    public static ConfigEntry<float> yCordCoil;
+    public static ConfigEntry<float> zCordCoil;
+
+    public static ConfigEntry<float> xRotCoil;
+    public static ConfigEntry<float> yRotCoil;
+    public static ConfigEntry<float> zRotCoil;
+
+    //Store Items
+    public static ConfigEntry<bool> deleteTeleporterCord;
+    public static ConfigEntry<bool> moveTeleButtonsToDesk;
+
+    //Inside Ship
+    public static ConfigEntry<bool> deleteTube; //initializes the config entry for each ship item, uses LethalConfig
+    public static ConfigEntry<bool> deleteBunkbeds;
+    public static ConfigEntry<bool> deleteFileCabinets;
+    public static ConfigEntry<bool> deleteOxygenTank;
+    public static ConfigEntry<bool> deleteClipboard;
+    public static ConfigEntry<bool> deleteDoorGenerator;
+    public static ConfigEntry<bool> deleteBoots;
+    public static ConfigEntry<bool> deleteMask;
+    public static ConfigEntry<bool> deleteAirFilter;
+    public static ConfigEntry<bool> deleteStickyNote;
+    public static ConfigEntry<bool> deleteBatteries;
+    public static ConfigEntry<bool> deleteVent;
+    public static ConfigEntry<bool> deleteMonitorCords;
+    public static ConfigEntry<bool> deleteDoorSpeaker;
+    public static ConfigEntry<bool> deleteMainSpeaker;
+    public static ConfigEntry<bool> deletePosters;
+    public static ConfigEntry<bool> deleteClothingRack;
+    public static ConfigEntry<bool> deleteDoorTubes;
+    public static ConfigEntry<bool> deleteKeyboardCord;
+    public static ConfigEntry<bool> terminalReposition;
+
+    //Outside Ship
+    public static ConfigEntry<bool> deleteFloodLight;
+    public static ConfigEntry<bool> deleteOutsideTubing;
+    public static ConfigEntry<bool> deleteMachinery;
+    public static ConfigEntry<bool> deleteRailing;
+    public static ConfigEntry<bool> deleteThrusterTube;
+    public static ConfigEntry<bool> deleteThrusters;
+    public static ConfigEntry<bool> deleteSupportBeams;
+    public static ConfigEntry<bool> deleteWeirdBox;
+    public static ConfigEntry<bool> deleteLeftMachinery;
+
+    //Misc
+    public static ConfigEntry<bool> parkourMode;
+    public static ConfigEntry<bool> lowLightMode;
+
+
+    public Config(ConfigFile cfg)
     {
-        private const string terminalmove = "Terminal Reposition";
-
-        private const string chargingcoil = "Charging Coil Reposition";
-
-        private const string inside = "Inside Ship";
-
-        private const string outside = "Outside Ship";
-
-        private const string storeItems = "Store Items";
-
-        private const string misc = "Misc Modes";
-
         //Custom Terminal Coords
-        public static ConfigEntry<bool> customTerminal;
-        public static ConfigEntry<float> xCordTerm;
-        public static ConfigEntry<float> yCordTerm;
-        public static ConfigEntry<float> zCordTerm;
 
-        public static ConfigEntry<float> xRotTerm;
-        public static ConfigEntry<float> yRotTerm;
-        public static ConfigEntry<float> zRotTerm;
+        terminalReposition = cfg.Bind(
+            terminalmove,
+            "Automatic Terminal Reposition",
+            false,
+            "Sets the terminal to the left of the monitors by default."
+        );
+        var terminalRepositionToggle = new BoolCheckBoxConfigItem(terminalReposition, false);
+        LethalConfigManager.AddConfigItem(terminalRepositionToggle);
+
+        customTerminal = cfg.Bind(
+            terminalmove,
+            "Custom Terminal Coordinates",
+            false,
+            "Allows the custom coordinates to be set. [CAUTION] Having this enabled disables the native ship furniture moving feature. You can enable/disable this in real-time in the pause menu."
+        );
+        var termCustomMoveToggle = new BoolCheckBoxConfigItem(customTerminal, false);
+        LethalConfigManager.AddConfigItem(termCustomMoveToggle);
+
+        xCordTerm = cfg.Bind(
+            terminalmove,
+            "X-Coordinate",
+            6.1759f,
+            "Sets X-coordinate of Terminal"
+        );
+        var termX = new FloatInputFieldConfigItem(xCordTerm, false);
+        LethalConfigManager.AddConfigItem(termX);
+
+        yCordTerm = cfg.Bind(
+            terminalmove,
+            "Y-Coordinate",
+            1.2561f,
+            "Sets Y-coordinate of Terminal"
+        );
+        var termY = new FloatInputFieldConfigItem(yCordTerm, false);
+        LethalConfigManager.AddConfigItem(termY);
+
+        zCordTerm = cfg.Bind(
+            terminalmove,
+            "Z-Coordinate",
+            -9.1415f,
+            "Sets Z-coordinate of Terminal"
+        );
+        var termZ = new FloatInputFieldConfigItem(zCordTerm, false);
+        LethalConfigManager.AddConfigItem(termZ);
+
+        xRotTerm = cfg.Bind(
+            terminalmove,
+            "X-Rotation",
+            270f,
+            "Sets X-Rotation of Terminal"
+        );
+        var termRotX = new FloatInputFieldConfigItem(xRotTerm, false);
+        LethalConfigManager.AddConfigItem(termRotX);
+
+        yRotTerm = cfg.Bind(
+            terminalmove,
+            "Y-Rotation",
+            90f,
+            "Sets Y-Rotation of Terminal"
+        );
+        var termRotY = new FloatInputFieldConfigItem(yRotTerm, false);
+        LethalConfigManager.AddConfigItem(termRotY);
+
+        zRotTerm = cfg.Bind(
+            terminalmove,
+            "Z-Rotation",
+            0f,
+            "Sets Z-Rotation of Terminal"
+        );
+        var termRotZ = new FloatInputFieldConfigItem(zRotTerm, false);
+        LethalConfigManager.AddConfigItem(termRotZ);
+
 
         //Custom Coil Coords
-        public static ConfigEntry<bool> moveCoil;
-        public static ConfigEntry<float> xCordCoil;
-        public static ConfigEntry<float> yCordCoil;
-        public static ConfigEntry<float> zCordCoil;
 
-        public static ConfigEntry<float> xRotCoil;
-        public static ConfigEntry<float> yRotCoil;
-        public static ConfigEntry<float> zRotCoil;
+        moveCoil = cfg.Bind(
+            chargingcoil,
+            "Move Coil",
+            false,
+            "Allows the custom coordinates to be set"
+        );
+        var coilMoveToggle = new BoolCheckBoxConfigItem(moveCoil, false);
+        LethalConfigManager.AddConfigItem(coilMoveToggle);
 
-        //Store Items
-        public static ConfigEntry<bool> deleteTeleporterCord;
-        public static ConfigEntry<bool> moveTeleButtonsToDesk;
+        xCordCoil = cfg.Bind(
+            chargingcoil,
+            "X-Coordinate",
+            -0.343f,
+            "Sets X-coordinate of Charging Coil"
+        );
+        var coilX = new FloatInputFieldConfigItem(xCordCoil, false);
+        LethalConfigManager.AddConfigItem(coilX);
+
+        yCordCoil = cfg.Bind(
+            chargingcoil,
+            "Y-Coordinate",
+            1.2561f,
+            "Sets Y-coordinate of Charging Coil"
+        );
+        var coilY = new FloatInputFieldConfigItem(yCordCoil, false);
+        LethalConfigManager.AddConfigItem(coilY);
+
+        zCordCoil = cfg.Bind(
+            chargingcoil,
+            "Z-Coordinate",
+            -4.802f,
+            "Sets Z-coordinate of Charging Coil"
+        );
+        var coilZ = new FloatInputFieldConfigItem(zCordCoil, false);
+        LethalConfigManager.AddConfigItem(coilZ);
+
+        xRotCoil = cfg.Bind(
+            chargingcoil,
+            "X-Rotation",
+            270f,
+            "Sets X-Rotation of Charging Coil"
+        );
+        var rotX = new FloatInputFieldConfigItem(xRotCoil, false);
+        LethalConfigManager.AddConfigItem(rotX);
+
+        yRotCoil = cfg.Bind(
+            chargingcoil,
+            "Y-Rotation",
+            0.0009f,
+            "Sets Y-Rotation of Charging Coil"
+        );
+        var rotY = new FloatInputFieldConfigItem(yRotCoil, false);
+        LethalConfigManager.AddConfigItem(rotY);
+
+        zRotCoil = cfg.Bind(
+            chargingcoil,
+            "Z-Rotation",
+            0f,
+            "Sets Z-Rotation of Charging Coil"
+        );
+        var rotZ = new FloatInputFieldConfigItem(zRotCoil, false);
+        LethalConfigManager.AddConfigItem(rotZ);
+
 
         //Inside Ship
-        public static ConfigEntry<bool> deleteTube;                 //initializes the config entry for each ship item, uses LethalConfig
-        public static ConfigEntry<bool> deleteBunkbeds;
-        public static ConfigEntry<bool> deleteFileCabinets;
-        public static ConfigEntry<bool> deleteOxygenTank;
-        public static ConfigEntry<bool> deleteClipboard;
-        public static ConfigEntry<bool> deleteDoorGenerator;
-        public static ConfigEntry<bool> deleteBoots;
-        public static ConfigEntry<bool> deleteMask;
-        public static ConfigEntry<bool> deleteAirFilter;
-        public static ConfigEntry<bool> deleteStickyNote;
-        public static ConfigEntry<bool> deleteBatteries;
-        public static ConfigEntry<bool> deleteVent;
-        public static ConfigEntry<bool> deleteMonitorCords;
-        public static ConfigEntry<bool> deleteDoorSpeaker;
-        public static ConfigEntry<bool> deleteMainSpeaker;
-        public static ConfigEntry<bool> deletePosters;
-        public static ConfigEntry<bool> deleteClothingRack;
-        public static ConfigEntry<bool> deleteDoorTubes;
-        public static ConfigEntry<bool> deleteKeyboardCord;
-        public static ConfigEntry<bool> terminalReposition;
-
-        //Outside Ship
-        public static ConfigEntry<bool> deleteFloodLight;
-        public static ConfigEntry<bool> deleteOutsideTubing;
-        public static ConfigEntry<bool> deleteMachinery;
-        public static ConfigEntry<bool> deleteRailing;
-        public static ConfigEntry<bool> deleteThrusterTube;
-        public static ConfigEntry<bool> deleteThrusters;
-        public static ConfigEntry<bool> deleteSupportBeams;
-        public static ConfigEntry<bool> deleteWeirdBox;
-        public static ConfigEntry<bool> deleteLeftMachinery;
-
-        //Misc
-        public static ConfigEntry<bool> parkourMode;
-        public static ConfigEntry<bool> lowLightMode;
-
-
-
-        public Config(ConfigFile cfg)
-        {
-            //Custom Terminal Coords
-
-            terminalReposition = cfg.Bind(
-               terminalmove,
-               "Automatic Terminal Reposition",
-               false,
-               "Sets the terminal to the left of the monitors by default."
-           );
-            var terminalRepositionToggle = new BoolCheckBoxConfigItem(terminalReposition, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(terminalRepositionToggle);
-
-            customTerminal= cfg.Bind(
-             terminalmove,
-             "Custom Terminal Coordinates",
-             false,
-             "Allows the custom coordinates to be set. [CAUTION] Having this enabled disables the native ship furniture moving feature. You can enable/disable this in real-time in the pause menu."
-         ); var termCustomMoveToggle = new BoolCheckBoxConfigItem(customTerminal, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(termCustomMoveToggle);
-
-            xCordTerm = cfg.Bind(
-             terminalmove,
-             "X-Coordinate",
-             6.1759f,
-             "Sets X-coordinate of Terminal"
-         );
-            var termX = new FloatInputFieldConfigItem(xCordTerm, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(termX);
-
-            yCordTerm = cfg.Bind(
-             terminalmove,
-             "Y-Coordinate",
-             1.2561f,
-             "Sets Y-coordinate of Terminal"
-         );
-            var termY = new FloatInputFieldConfigItem(yCordTerm, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(termY);
-
-            zCordTerm = cfg.Bind(
-             terminalmove,
-             "Z-Coordinate",
-             -9.1415f,
-             "Sets Z-coordinate of Terminal"
-         );
-            var termZ = new FloatInputFieldConfigItem(zCordTerm, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(termZ);
-
-            xRotTerm = cfg.Bind(
-             terminalmove,
-             "X-Rotation",
-             270f,
-             "Sets X-Rotation of Terminal"
-         );
-            var termRotX = new FloatInputFieldConfigItem(xRotTerm, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(termRotX);
-
-            yRotTerm = cfg.Bind(
-             terminalmove,
-             "Y-Rotation",
-             90f,
-             "Sets Y-Rotation of Terminal"
-         );
-            var termRotY = new FloatInputFieldConfigItem(yRotTerm, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(termRotY);
-
-            zRotTerm = cfg.Bind(
-             terminalmove,
-             "Z-Rotation",
-             0f,
-             "Sets Z-Rotation of Terminal"
-         );
-            var termRotZ = new FloatInputFieldConfigItem(zRotTerm, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(termRotZ);
-
-
-
-            //Custom Coil Coords
-
-            moveCoil = cfg.Bind(
-             chargingcoil,
-             "Move Coil",
-             false,
-             "Allows the custom coordinates to be set"
-         ); var coilMoveToggle = new BoolCheckBoxConfigItem(moveCoil, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(coilMoveToggle);
-
-            xCordCoil = cfg.Bind(
-             chargingcoil,
-             "X-Coordinate",
-             -0.343f,
-             "Sets X-coordinate of Charging Coil"
-         );
-            var coilX = new FloatInputFieldConfigItem(xCordCoil, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(coilX);
-
-            yCordCoil = cfg.Bind(
-             chargingcoil,
-             "Y-Coordinate",
-             1.2561f,
-             "Sets Y-coordinate of Charging Coil"
-         );
-            var coilY = new FloatInputFieldConfigItem(yCordCoil, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(coilY);
-
-            zCordCoil = cfg.Bind(
-             chargingcoil,
-             "Z-Coordinate",
-             -4.802f,
-             "Sets Z-coordinate of Charging Coil"
-         );
-            var coilZ = new FloatInputFieldConfigItem(zCordCoil, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(coilZ);
-
-            xRotCoil = cfg.Bind(
-             chargingcoil,
-             "X-Rotation",
-             270f,
-             "Sets X-Rotation of Charging Coil"
-         );
-            var rotX = new FloatInputFieldConfigItem(xRotCoil, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(rotX);
-
-            yRotCoil = cfg.Bind(
-             chargingcoil,
-             "Y-Rotation",
-             0.0009f,
-             "Sets Y-Rotation of Charging Coil"
-         );
-            var rotY = new FloatInputFieldConfigItem(yRotCoil, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(rotY);
-
-            zRotCoil = cfg.Bind(
-             chargingcoil,
-             "Z-Rotation",
-             0f,
-             "Sets Z-Rotation of Charging Coil"
-         );
-            var rotZ = new FloatInputFieldConfigItem(zRotCoil, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(rotZ);
-
-
-
-
-            //Inside Ship
-
-            deleteTube = cfg.Bind(                                  //sets initial LethalConfig values
-                   inside,                                           //type of change
-                   "Tube",                                              //Name in the UI
-                   true,                                                //default value
-                   "Deletes the tube on the floor"                      //Description for UI
-               );
-            var tubeToggle = new BoolCheckBoxConfigItem(deleteTube, requiresRestart: false);    //sets as checkbox for bool, sets restart flag as false as these changes do not require a restart of the game
-            LethalConfigManager.AddConfigItem(tubeToggle);
-
-            deleteBunkbeds = cfg.Bind(
-                inside,
-                "BunkBeds",
-                false,
-                "Deletes the bunkbeds"
-            );
-            var bedToggle = new BoolCheckBoxConfigItem(deleteBunkbeds, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(bedToggle);
-
-            deleteFileCabinets = cfg.Bind(
-               inside,
-                "File Cabinets",
-                false,
-                "Deletes the file cabinets"
-            );
-            var fileCabinetsToggle = new BoolCheckBoxConfigItem(deleteFileCabinets, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(fileCabinetsToggle);
-
-            deleteOxygenTank = cfg.Bind(
-                inside,
-                "Oxygen Tank",
-                false,
-                "Deletes the oxygen tank"
-            );
-            var oxygenTankToggle = new BoolCheckBoxConfigItem(deleteOxygenTank, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(oxygenTankToggle);
-
-            deleteClipboard = cfg.Bind(
-                inside,
-                "Clipboard",
-                false,
-                "Deletes the clipboard"
-            );
-            var clipboardToggle = new BoolCheckBoxConfigItem(deleteClipboard, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(clipboardToggle);
-
-            deleteDoorGenerator = cfg.Bind(
-                inside,
-                "Door Generator",
-                false,
-                "Deletes the door generator"
-            );
-            var doorGeneratorToggle = new BoolCheckBoxConfigItem(deleteDoorGenerator, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(doorGeneratorToggle);
-
-            deleteBoots = cfg.Bind(
-                inside,
-                "Boots",
-                false,
-                "Deletes the boots under the clothing rack"
-            );
-            var bootsToggle = new BoolCheckBoxConfigItem(deleteBoots, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(bootsToggle);
-
-            deleteMask = cfg.Bind(
-                inside,
-                "Mask",
-                false,
-                "Deletes the mask on the control desk"
-            );
-            var maskToggle = new BoolCheckBoxConfigItem(deleteMask, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(maskToggle);
-
-            deleteAirFilter = cfg.Bind(
-                inside,
-                "Air Filter",
-                false,
-                "Deletes the air filter on the wall"
-            );
-            var airFilterToggle = new BoolCheckBoxConfigItem(deleteAirFilter, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(airFilterToggle);
-
-            deleteStickyNote = cfg.Bind(
-                inside,
-                "Sticky Note",
-                false,
-                "Deletes the sticky note"
-            );
-            var stickyNoteToggle = new BoolCheckBoxConfigItem(deleteStickyNote, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(stickyNoteToggle);
-
-            deleteBatteries = cfg.Bind(
-                inside,
-                "Batteries",
-                false,
-                "Deletes the batteries on control desk"
-            );
-            var batteryToggle = new BoolCheckBoxConfigItem(deleteBatteries, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(batteryToggle);
-
-            deleteVent = cfg.Bind(
-                inside,
-                "Vent",
-                false,
-                "Deletes the vent below the charging station"
-            );
-            var ventToggle = new BoolCheckBoxConfigItem(deleteVent, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(ventToggle);
-
-            deleteMonitorCords = cfg.Bind(
-               inside,
-               "Monitor Cords",
-               false,
-               "Deletes the cords behind the monitors"
-           );
-            var monitorCordsToggle = new BoolCheckBoxConfigItem(deleteMonitorCords, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(monitorCordsToggle);
-
-            deleteDoorSpeaker = cfg.Bind(
-               inside,
-               "Door Speaker",
-               false,
-               "Deletes the speaker near the ship door"
-           );
-            var doorSpeakerToggle = new BoolCheckBoxConfigItem(deleteDoorSpeaker, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(doorSpeakerToggle);
-
-            deleteMainSpeaker = cfg.Bind(
-               inside,
-               "Main Speaker",
-               false,
-               "Deletes the main speaker that normally plays audio. WARNING: No ship-speaker audio will play if this is selected!"
-           );
-            var mainSpeakerToggle = new BoolCheckBoxConfigItem(deleteMainSpeaker, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(mainSpeakerToggle);
-
-            deletePosters = cfg.Bind(
-               inside,
-               "Posters",
-               false,
-               "Deletes the posters inside the ship"
-           );
-            var postersToggle = new BoolCheckBoxConfigItem(deletePosters, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(postersToggle);
-
-            deleteClothingRack = cfg.Bind(
-               inside,
-               "Clothing Rack",
-               false,
-               "Deletes the clothing rack. WARNING: Purchasable suits will not be able to be equipped if this is selected!"
-           );
-            var clothingRackToggle = new BoolCheckBoxConfigItem(deleteClothingRack, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(clothingRackToggle);
-
-            deleteDoorTubes = cfg.Bind(
-               inside,
-               "Door Tubes",
-               false,
-               "Deletes the tubes by the ship door."
-           );
-            var doorTubesToggle = new BoolCheckBoxConfigItem(deleteDoorTubes, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(doorTubesToggle);
-
-            deleteKeyboardCord = cfg.Bind(
-               inside,
-               "Keyboard Cord",
-               true,
-               "Deletes the cord coming out of the keyboard on the terminal"
-           );
-            var keyboardCordToggle = new BoolCheckBoxConfigItem(deleteKeyboardCord, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(keyboardCordToggle);
-
-
-            // OUTSIDE SHIP
-            deleteFloodLight = cfg.Bind(
-               outside,
-               "Floodlight",
-               false,
-               "Removes the floodlight outside the ship"
-           );
-            var deleteFloodlightToggle = new BoolCheckBoxConfigItem(deleteFloodLight, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(deleteFloodlightToggle);
-
-            deleteMachinery = cfg.Bind(
-               outside,
-               "Machinery Boxes",
-               false,
-               "Removes the machinery boxes on both sides of the ship"
-           );
-            var machineryToggle = new BoolCheckBoxConfigItem(deleteMachinery, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(machineryToggle);
-
-            deleteOutsideTubing = cfg.Bind(
-               outside,
-               "Tubing",
-               false,
-               "Removes the tubing outside the ship"
-           );
-            var outsideTubingToggle = new BoolCheckBoxConfigItem(deleteOutsideTubing, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(outsideTubingToggle);
-
-            deleteRailing = cfg.Bind(
-               outside,
-               "Railing",
-               false,
-               "Removes the railing outside the ship"
-           );
-            var railingToggle = new BoolCheckBoxConfigItem(deleteRailing, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(railingToggle);
-
-            deleteThrusterTube = cfg.Bind(
-              outside,
-               "Back Right Thruster Tube",
-               false,
-               "Removes the thruster tube in the back right. NOTE: Also deletes back right thruster"
-           );
-            var thrusterTubeToggle = new BoolCheckBoxConfigItem(deleteThrusterTube, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(thrusterTubeToggle);
-
-            deleteThrusters = cfg.Bind(
-               outside,
-               "All Thrusters",
-               false,
-               "Removes all thrusters."
-           );
-            var thrustersToggle = new BoolCheckBoxConfigItem(deleteThrusters, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(thrustersToggle);
-
-            deleteSupportBeams = cfg.Bind(
-               outside,
-               "Support Beams Under Ship",
-               false,
-               "Removes support beams."
-           );
-            var supportBeamsToggle = new BoolCheckBoxConfigItem(deleteSupportBeams, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(thrustersToggle);
-
-            deleteWeirdBox = cfg.Bind(
-               outside,
-               "Large Exhaust",
-               false,
-               "Removes large exhaust box near front of ship"
-           );
-            var weirdBoxToggle = new BoolCheckBoxConfigItem(deleteWeirdBox, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(thrustersToggle);
-
-            deleteLeftMachinery = cfg.Bind(
-               outside,
-               "Left Machinery",
-               false,
-               "Removes machinery and bottom tubing from left of ship"
-           );
-            var leftMachineryToggle = new BoolCheckBoxConfigItem(deleteLeftMachinery, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(leftMachineryToggle);
-
-
-
-
-            //MISC MODES
-            parkourMode = cfg.Bind(
-              misc,
-              "Parkour Mode",
-              false,
-              "Only for the bravest Company Employees. Removes catwalk and ladders from the outside of the ship."
-          );
-            var parkourToggle = new BoolCheckBoxConfigItem(parkourMode, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(parkourToggle);
-
-            lowLightMode = cfg.Bind(
-             misc,
-             "Low Light Mode",
-             false,
-             "Removes some lights inside the ship"
-         );
-            var lightToggle = new BoolCheckBoxConfigItem(lowLightMode, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(lightToggle);
-
-
-
-            //Store Items
-            deleteTeleporterCord = cfg.Bind(
-             storeItems,
-             "Teleporter Cord",
-             false,
-             "Removes the long cord from the teleporter"
-         );
-            var teleCordToggle = new BoolCheckBoxConfigItem(deleteTeleporterCord, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(teleCordToggle);
-
-            moveTeleButtonsToDesk = cfg.Bind(
-             storeItems,
-             "Teleporter Buttons",
-             false,
-             "Moves the teleporter buttons to the desk near the ship lever"
-         );
-            var teleButtonsToggle = new BoolCheckBoxConfigItem(moveTeleButtonsToDesk, requiresRestart: false);
-            LethalConfigManager.AddConfigItem(teleButtonsToggle);
-        }
+
+        deleteTube = cfg.Bind( //sets initial LethalConfig values
+            inside, //type of change
+            "Tube", //Name in the UI
+            true, //default value
+            "Deletes the tube on the floor" //Description for UI
+        );
+        var tubeToggle =
+            new BoolCheckBoxConfigItem(deleteTube,
+                false); //sets as checkbox for bool, sets restart flag as false as these changes do not require a restart of the game
+        LethalConfigManager.AddConfigItem(tubeToggle);
+
+        deleteBunkbeds = cfg.Bind(
+            inside,
+            "BunkBeds",
+            false,
+            "Deletes the bunkbeds"
+        );
+        var bedToggle = new BoolCheckBoxConfigItem(deleteBunkbeds, false);
+        LethalConfigManager.AddConfigItem(bedToggle);
+
+        deleteFileCabinets = cfg.Bind(
+            inside,
+            "File Cabinets",
+            false,
+            "Deletes the file cabinets"
+        );
+        var fileCabinetsToggle = new BoolCheckBoxConfigItem(deleteFileCabinets, false);
+        LethalConfigManager.AddConfigItem(fileCabinetsToggle);
+
+        deleteOxygenTank = cfg.Bind(
+            inside,
+            "Oxygen Tank",
+            false,
+            "Deletes the oxygen tank"
+        );
+        var oxygenTankToggle = new BoolCheckBoxConfigItem(deleteOxygenTank, false);
+        LethalConfigManager.AddConfigItem(oxygenTankToggle);
+
+        deleteClipboard = cfg.Bind(
+            inside,
+            "Clipboard",
+            false,
+            "Deletes the clipboard"
+        );
+        var clipboardToggle = new BoolCheckBoxConfigItem(deleteClipboard, false);
+        LethalConfigManager.AddConfigItem(clipboardToggle);
+
+        deleteDoorGenerator = cfg.Bind(
+            inside,
+            "Door Generator",
+            false,
+            "Deletes the door generator"
+        );
+        var doorGeneratorToggle = new BoolCheckBoxConfigItem(deleteDoorGenerator, false);
+        LethalConfigManager.AddConfigItem(doorGeneratorToggle);
+
+        deleteBoots = cfg.Bind(
+            inside,
+            "Boots",
+            false,
+            "Deletes the boots under the clothing rack"
+        );
+        var bootsToggle = new BoolCheckBoxConfigItem(deleteBoots, false);
+        LethalConfigManager.AddConfigItem(bootsToggle);
+
+        deleteMask = cfg.Bind(
+            inside,
+            "Mask",
+            false,
+            "Deletes the mask on the control desk"
+        );
+        var maskToggle = new BoolCheckBoxConfigItem(deleteMask, false);
+        LethalConfigManager.AddConfigItem(maskToggle);
+
+        deleteAirFilter = cfg.Bind(
+            inside,
+            "Air Filter",
+            false,
+            "Deletes the air filter on the wall"
+        );
+        var airFilterToggle = new BoolCheckBoxConfigItem(deleteAirFilter, false);
+        LethalConfigManager.AddConfigItem(airFilterToggle);
+
+        deleteStickyNote = cfg.Bind(
+            inside,
+            "Sticky Note",
+            false,
+            "Deletes the sticky note"
+        );
+        var stickyNoteToggle = new BoolCheckBoxConfigItem(deleteStickyNote, false);
+        LethalConfigManager.AddConfigItem(stickyNoteToggle);
+
+        deleteBatteries = cfg.Bind(
+            inside,
+            "Batteries",
+            false,
+            "Deletes the batteries on control desk"
+        );
+        var batteryToggle = new BoolCheckBoxConfigItem(deleteBatteries, false);
+        LethalConfigManager.AddConfigItem(batteryToggle);
+
+        deleteVent = cfg.Bind(
+            inside,
+            "Vent",
+            false,
+            "Deletes the vent below the charging station"
+        );
+        var ventToggle = new BoolCheckBoxConfigItem(deleteVent, false);
+        LethalConfigManager.AddConfigItem(ventToggle);
+
+        deleteMonitorCords = cfg.Bind(
+            inside,
+            "Monitor Cords",
+            false,
+            "Deletes the cords behind the monitors"
+        );
+        var monitorCordsToggle = new BoolCheckBoxConfigItem(deleteMonitorCords, false);
+        LethalConfigManager.AddConfigItem(monitorCordsToggle);
+
+        deleteDoorSpeaker = cfg.Bind(
+            inside,
+            "Door Speaker",
+            false,
+            "Deletes the speaker near the ship door"
+        );
+        var doorSpeakerToggle = new BoolCheckBoxConfigItem(deleteDoorSpeaker, false);
+        LethalConfigManager.AddConfigItem(doorSpeakerToggle);
+
+        deleteMainSpeaker = cfg.Bind(
+            inside,
+            "Main Speaker",
+            false,
+            "Deletes the main speaker that normally plays audio. WARNING: No ship-speaker audio will play if this is selected!"
+        );
+        var mainSpeakerToggle = new BoolCheckBoxConfigItem(deleteMainSpeaker, false);
+        LethalConfigManager.AddConfigItem(mainSpeakerToggle);
+
+        deletePosters = cfg.Bind(
+            inside,
+            "Posters",
+            false,
+            "Deletes the posters inside the ship"
+        );
+        var postersToggle = new BoolCheckBoxConfigItem(deletePosters, false);
+        LethalConfigManager.AddConfigItem(postersToggle);
+
+        deleteClothingRack = cfg.Bind(
+            inside,
+            "Clothing Rack",
+            false,
+            "Deletes the clothing rack. WARNING: Purchasable suits will not be able to be equipped if this is selected!"
+        );
+        var clothingRackToggle = new BoolCheckBoxConfigItem(deleteClothingRack, false);
+        LethalConfigManager.AddConfigItem(clothingRackToggle);
+
+        deleteDoorTubes = cfg.Bind(
+            inside,
+            "Door Tubes",
+            false,
+            "Deletes the tubes by the ship door."
+        );
+        var doorTubesToggle = new BoolCheckBoxConfigItem(deleteDoorTubes, false);
+        LethalConfigManager.AddConfigItem(doorTubesToggle);
+
+        deleteKeyboardCord = cfg.Bind(
+            inside,
+            "Keyboard Cord",
+            true,
+            "Deletes the cord coming out of the keyboard on the terminal"
+        );
+        var keyboardCordToggle = new BoolCheckBoxConfigItem(deleteKeyboardCord, false);
+        LethalConfigManager.AddConfigItem(keyboardCordToggle);
+
+
+        // OUTSIDE SHIP
+        deleteFloodLight = cfg.Bind(
+            outside,
+            "Floodlight",
+            false,
+            "Removes the floodlight outside the ship"
+        );
+        var deleteFloodlightToggle = new BoolCheckBoxConfigItem(deleteFloodLight, false);
+        LethalConfigManager.AddConfigItem(deleteFloodlightToggle);
+
+        deleteMachinery = cfg.Bind(
+            outside,
+            "Machinery Boxes",
+            false,
+            "Removes the machinery boxes on both sides of the ship"
+        );
+        var machineryToggle = new BoolCheckBoxConfigItem(deleteMachinery, false);
+        LethalConfigManager.AddConfigItem(machineryToggle);
+
+        deleteOutsideTubing = cfg.Bind(
+            outside,
+            "Tubing",
+            false,
+            "Removes the tubing outside the ship"
+        );
+        var outsideTubingToggle = new BoolCheckBoxConfigItem(deleteOutsideTubing, false);
+        LethalConfigManager.AddConfigItem(outsideTubingToggle);
+
+        deleteRailing = cfg.Bind(
+            outside,
+            "Railing",
+            false,
+            "Removes the railing outside the ship"
+        );
+        var railingToggle = new BoolCheckBoxConfigItem(deleteRailing, false);
+        LethalConfigManager.AddConfigItem(railingToggle);
+
+        deleteThrusterTube = cfg.Bind(
+            outside,
+            "Back Right Thruster Tube",
+            false,
+            "Removes the thruster tube in the back right. NOTE: Also deletes back right thruster"
+        );
+        var thrusterTubeToggle = new BoolCheckBoxConfigItem(deleteThrusterTube, false);
+        LethalConfigManager.AddConfigItem(thrusterTubeToggle);
+
+        deleteThrusters = cfg.Bind(
+            outside,
+            "All Thrusters",
+            false,
+            "Removes all thrusters."
+        );
+        var thrustersToggle = new BoolCheckBoxConfigItem(deleteThrusters, false);
+        LethalConfigManager.AddConfigItem(thrustersToggle);
+
+        deleteSupportBeams = cfg.Bind(
+            outside,
+            "Support Beams Under Ship",
+            false,
+            "Removes support beams."
+        );
+        var supportBeamsToggle = new BoolCheckBoxConfigItem(deleteSupportBeams, false);
+        LethalConfigManager.AddConfigItem(thrustersToggle);
+
+        deleteWeirdBox = cfg.Bind(
+            outside,
+            "Large Exhaust",
+            false,
+            "Removes large exhaust box near front of ship"
+        );
+        var weirdBoxToggle = new BoolCheckBoxConfigItem(deleteWeirdBox, false);
+        LethalConfigManager.AddConfigItem(thrustersToggle);
+
+        deleteLeftMachinery = cfg.Bind(
+            outside,
+            "Left Machinery",
+            false,
+            "Removes machinery and bottom tubing from left of ship"
+        );
+        var leftMachineryToggle = new BoolCheckBoxConfigItem(deleteLeftMachinery, false);
+        LethalConfigManager.AddConfigItem(leftMachineryToggle);
+
+
+        //MISC MODES
+        parkourMode = cfg.Bind(
+            misc,
+            "Parkour Mode",
+            false,
+            "Only for the bravest Company Employees. Removes catwalk and ladders from the outside of the ship."
+        );
+        var parkourToggle = new BoolCheckBoxConfigItem(parkourMode, false);
+        LethalConfigManager.AddConfigItem(parkourToggle);
+
+        lowLightMode = cfg.Bind(
+            misc,
+            "Low Light Mode",
+            false,
+            "Removes some lights inside the ship"
+        );
+        var lightToggle = new BoolCheckBoxConfigItem(lowLightMode, false);
+        LethalConfigManager.AddConfigItem(lightToggle);
+
+
+        //Store Items
+        deleteTeleporterCord = cfg.Bind(
+            storeItems,
+            "Teleporter Cord",
+            false,
+            "Removes the long cord from the teleporter"
+        );
+        var teleCordToggle = new BoolCheckBoxConfigItem(deleteTeleporterCord, false);
+        LethalConfigManager.AddConfigItem(teleCordToggle);
+
+        moveTeleButtonsToDesk = cfg.Bind(
+            storeItems,
+            "Teleporter Buttons",
+            false,
+            "Moves the teleporter buttons to the desk near the ship lever"
+        );
+        var teleButtonsToggle = new BoolCheckBoxConfigItem(moveTeleButtonsToDesk, false);
+        LethalConfigManager.AddConfigItem(teleButtonsToggle);
     }
 }

--- a/LethalTubeRemoval.csproj
+++ b/LethalTubeRemoval.csproj
@@ -1,37 +1,40 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
 
-  <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\core\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\core\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="LethalConfig">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\plugins\LethalConfig\LethalConfig.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.Netcode.Runtime">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-	<Target Name="CopyDLLs" AfterTargets="Build" Condition="$(Configuration) == 'Debug' or $(Configuration) == 'Release' ">
-		<Message Text="Executing CopyDLLs task" Importance="High" />
-		<Copy SourceFiles="$(TargetDir)$(ProjectName).dll" DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\plugins" />
-		<Message Text="Copied build files" Importance="High" />
-	</Target>
+        <!-- NuGet Information -->
+        <RestoreAdditionalProjectSources>
+            https://api.nuget.org/v3/index.json;
+            https://nuget.bepinex.dev/v3/index.json
+        </RestoreAdditionalProjectSources>
+    </PropertyGroup>
+
+    <!-- BepInEx Package References -->
+    <ItemGroup>
+        <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all"/>
+        <PackageReference Include="BepInEx.Core" Version="5.*"/>
+        <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*"/>
+        <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" ExcludeAssets="runtime"/>
+        <PackageReference Include="UnityEngine.Modules" Version="2022.3.9" IncludeAssets="compile"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Reference Include="Assembly-CSharp">
+            <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
+        </Reference>
+        <Reference Include="LethalConfig">
+            <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\plugins\LethalConfig\LethalConfig.dll</HintPath>
+        </Reference>
+        <Reference Include="Unity.Netcode.Runtime">
+            <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
+        </Reference>
+    </ItemGroup>
+    <Target Name="CopyDLLs" AfterTargets="Build" Condition="$(Configuration) == 'Debug' or $(Configuration) == 'Release' ">
+        <Message Text="Executing CopyDLLs task" Importance="High"/>
+        <Copy SourceFiles="$(TargetDir)$(ProjectName).dll" DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\BepInEx\plugins"/>
+        <Message Text="Copied build files" Importance="High"/>
+    </Target>
 </Project>

--- a/Patches/OutsideShipPatch.cs
+++ b/Patches/OutsideShipPatch.cs
@@ -1,137 +1,128 @@
 ﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
-using BepInEx;
-using System.Runtime.CompilerServices;
 using Object = UnityEngine.Object;
-using static LethalTubeRemoval.TubeRemoval;
 
-namespace LethalTubeRemoval.Patches
+namespace LethalTubeRemoval.Patches;
+
+internal class OutsideShipPatch
 {
-    internal class OutsideShipPatch
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(StartOfRound), "Start")] //runs the patch each time the round is started
+    private static void OutsideShip()
     {
-        [HarmonyPostfix]
-        [HarmonyPatch(typeof(StartOfRound), "Start")]           //runs the patch each time the round is started
-        static void OutsideShip()
+        var floodLight =
+            GameObject.Find(
+                "Environment/HangarShip/ShipModels2b/ShipLightsPost"); //sets each ship item path as a GameObject
+        var leftMachinery = GameObject.Find("Environment/HangarShip/SideMachineryLeft");
+        var rightMachinery = GameObject.Find("Environment/HangarShip/SideMachineryRight");
+        var rightTubing1 = GameObject.Find("Environment/HangarShip/Cube.005");
+        var rightTubing2 = GameObject.Find("Environment/HangarShip/Cube.006");
+        var backTubing1 = GameObject.Find("Environment/HangarShip/Cube.007");
+        var backTubing2 = GameObject.Find("Environment/HangarShip/Cube.008");
+        var exhaustLeft = GameObject.Find("Environment/HangarShip/NurbsPath.001");
+        var weirdBoxRight = GameObject.Find("Environment/HangarShip/MeterBoxDevice.001");
+        var extraPipingLeft = GameObject.Find("Environment/HangarShip/Pipework2.002");
+
+
+        var railPosts = GameObject.Find("Environment/HangarShip/ShipRailPosts");
+        var rails = GameObject.Find("Environment/HangarShip/ShipRails");
+
+        var backRightThruster = GameObject.Find("Environment/HangarShip/ThrusterBackRight");
+        var backLeftThruster = GameObject.Find("Environment/HangarShip/ThrusterBackLeft");
+
+        var frontRightThruster = GameObject.Find("Environment/HangarShip/ThrusterFrontRight");
+        var frontLeftThruster = GameObject.Find("Environment/HangarShip/ThrusterFrontLeft");
+
+        var supportBeams1 = GameObject.Find("Environment/HangarShip/ShipSupportBeams");
+        var supportBeams2 = GameObject.Find("Environment/HangarShip/ShipSupportBeams.001");
+
+        var weirdBox = GameObject.Find("Environment/HangarShip/Cube.004");
+
+
+        //Catwalk stuff
+        var catWalk = GameObject.Find("Environment/HangarShip/CatwalkShip");
+        var catWalkRailLining1 = GameObject.Find("Environment/HangarShip/CatwalkRailLining");
+        var catWalkRailLining2 = GameObject.Find("Environment/HangarShip/CatwalkRailLiningB");
+        var catWalkSupports = GameObject.Find("Environment/HangarShip/CatwalkUnderneathSupports");
+
+        var bigLadder = GameObject.Find("Environment/HangarShip/OutsideShipRoom/Ladder");
+        var shortLadder1 = GameObject.Find("Environment/HangarShip/LadderShort");
+        var shortLadder2 = GameObject.Find("Environment/HangarShip/LadderShort (1)");
+        var catWalkHitbox = GameObject.Find("Environment/HangarShip/ClimbOntoCatwalkHelper");
+
+
+        if (Config.deleteFloodLight.Value) //checks config file for boolean value and if true deletes the item
+            Object.Destroy(floodLight);
+
+        if (Config.deleteMachinery.Value)
         {
-            GameObject floodLight = GameObject.Find("Environment/HangarShip/ShipModels2b/ShipLightsPost");        //sets each ship item path as a GameObject
-            GameObject leftMachinery = GameObject.Find("Environment/HangarShip/SideMachineryLeft");
-            GameObject rightMachinery = GameObject.Find("Environment/HangarShip/SideMachineryRight");
-            GameObject rightTubing1 = GameObject.Find("Environment/HangarShip/Cube.005");
-            GameObject rightTubing2 = GameObject.Find("Environment/HangarShip/Cube.006");
-            GameObject backTubing1 = GameObject.Find("Environment/HangarShip/Cube.007");
-            GameObject backTubing2 = GameObject.Find("Environment/HangarShip/Cube.008");
-            GameObject exhaustLeft = GameObject.Find("Environment/HangarShip/NurbsPath.001");
-            GameObject weirdBoxRight = GameObject.Find("Environment/HangarShip/MeterBoxDevice.001");
-            GameObject extraPipingLeft = GameObject.Find("Environment/HangarShip/Pipework2.002");
+            Object.Destroy(leftMachinery);
+            Object.Destroy(rightMachinery);
+            Object.Destroy(weirdBoxRight);
+            Object.Destroy(extraPipingLeft);
+        }
+        else if (Config.deleteLeftMachinery.Value)
+        {
+            Object.Destroy(leftMachinery);
+            Object.Destroy(extraPipingLeft);
+        }
+
+        if (Config.deleteOutsideTubing.Value)
+        {
+            Object.Destroy(rightTubing1);
+            Object.Destroy(rightTubing2);
+            Object.Destroy(backTubing1);
+            Object.Destroy(backTubing2);
+            Object.Destroy(exhaustLeft);
+        }
 
 
-            GameObject railPosts = GameObject.Find("Environment/HangarShip/ShipRailPosts");
-            GameObject rails = GameObject.Find("Environment/HangarShip/ShipRails");
+        if (Config.deleteThrusters.Value) //deletes all thrusters
+        {
+            Object.Destroy(backRightThruster);
+            Object.Destroy(frontRightThruster);
+            Object.Destroy(backLeftThruster);
+            Object.Destroy(frontLeftThruster);
+        }
+        else if
+            (Config.deleteThrusterTube
+             .Value) //if all thrusters have been chosen to be deleted, this will not run as it is redundant
+        {
+            Object.Destroy(backRightThruster);
+        }
 
-            GameObject backRightThruster = GameObject.Find("Environment/HangarShip/ThrusterBackRight");
-            GameObject backLeftThruster = GameObject.Find("Environment/HangarShip/ThrusterBackLeft");
+        if (Config.deleteSupportBeams.Value)
+        {
+            Object.Destroy(supportBeams1);
+            Object.Destroy(supportBeams2);
+        }
 
-            GameObject frontRightThruster = GameObject.Find("Environment/HangarShip/ThrusterFrontRight");
-            GameObject frontLeftThruster = GameObject.Find("Environment/HangarShip/ThrusterFrontLeft");
+        if (Config.deleteWeirdBox.Value) Object.Destroy(weirdBox);
 
-            GameObject supportBeams1 = GameObject.Find("Environment/HangarShip/ShipSupportBeams");
-            GameObject supportBeams2 = GameObject.Find("Environment/HangarShip/ShipSupportBeams.001");
-
-            GameObject weirdBox = GameObject.Find("Environment/HangarShip/Cube.004");
-
-
-            //Catwalk stuff
-            GameObject catWalk = GameObject.Find("Environment/HangarShip/CatwalkShip");
-            GameObject catWalkRailLining1 = GameObject.Find("Environment/HangarShip/CatwalkRailLining");
-            GameObject catWalkRailLining2 = GameObject.Find("Environment/HangarShip/CatwalkRailLiningB");
-            GameObject catWalkSupports = GameObject.Find("Environment/HangarShip/CatwalkUnderneathSupports");
-
-            GameObject bigLadder = GameObject.Find("Environment/HangarShip/OutsideShipRoom/Ladder");
-            GameObject shortLadder1 = GameObject.Find("Environment/HangarShip/LadderShort");
-            GameObject shortLadder2 = GameObject.Find("Environment/HangarShip/LadderShort (1)");
-            GameObject catWalkHitbox = GameObject.Find("Environment/HangarShip/ClimbOntoCatwalkHelper");
-
-
-
-            if (Config.deleteFloodLight.Value)            //checks config file for boolean value and if true deletes the item
+        if (Config.parkourMode.Value)
+        {
+            if (!Config.deleteSupportBeams.Value)
             {
-                GameObject.Destroy(floodLight);
+                Object.Destroy(supportBeams1);
+                Object.Destroy(supportBeams2);
             }
 
-            if (Config.deleteMachinery.Value)
-            {
-                GameObject.Destroy(leftMachinery);
-                GameObject.Destroy(rightMachinery);
-                GameObject.Destroy(weirdBoxRight);
-                GameObject.Destroy(extraPipingLeft);
-            }else if (Config.deleteLeftMachinery.Value)
-            {
-                GameObject.Destroy(leftMachinery);
-                GameObject.Destroy(extraPipingLeft);
-            }
-
-            if (Config.deleteOutsideTubing.Value)
-            {
-                GameObject.Destroy(rightTubing1);
-                GameObject.Destroy(rightTubing2);
-                GameObject.Destroy(backTubing1);
-                GameObject.Destroy(backTubing2);
-                GameObject.Destroy(exhaustLeft);
-            }
-
-            
-            if (Config.deleteThrusters.Value)                       //deletes all thrusters
-            {
-                GameObject.Destroy(backRightThruster);
-                GameObject.Destroy(frontRightThruster);
-                GameObject.Destroy(backLeftThruster);
-                GameObject.Destroy(frontLeftThruster);
-
-            }
-            else if (Config.deleteThrusterTube.Value)             //if all thrusters have been chosen to be deleted, this will not run as it is redundant
-            {
-                GameObject.Destroy(backRightThruster);
-            }
-
-            if (Config.deleteSupportBeams.Value)
-            {
-                GameObject.Destroy(supportBeams1);
-                GameObject.Destroy(supportBeams2);
-            }
-
-            if (Config.deleteWeirdBox.Value)
-            {
-                GameObject.Destroy(weirdBox);
-            }
-
-            if (Config.parkourMode.Value)
-            {
-                if(!Config.deleteSupportBeams.Value) 
-                {
-                    GameObject.Destroy(supportBeams1);
-                    GameObject.Destroy(supportBeams2);
-                }
-
-                GameObject.Destroy(catWalk);
-                GameObject.Destroy(catWalkRailLining1);
-                GameObject.Destroy(catWalkRailLining2);
-                GameObject.Destroy(catWalkSupports);
-                GameObject.Destroy(catWalkHitbox);
-                GameObject.Destroy(railPosts);
-                GameObject.Destroy(rails);
-                bigLadder.SetActive(false);             //ladders prevent door from closing as well, found setting the item as inactive instead of destroying it preserves door function
-                shortLadder1.SetActive(false);
-                shortLadder2.SetActive(false);
-            }else if (Config.deleteRailing.Value)
-            {
-                GameObject.Destroy(railPosts);
-                GameObject.Destroy(rails);
-            }
+            Object.Destroy(catWalk);
+            Object.Destroy(catWalkRailLining1);
+            Object.Destroy(catWalkRailLining2);
+            Object.Destroy(catWalkSupports);
+            Object.Destroy(catWalkHitbox);
+            Object.Destroy(railPosts);
+            Object.Destroy(rails);
+            bigLadder.SetActive(
+                false); //ladders prevent door from closing as well, found setting the item as inactive instead of destroying it preserves door function
+            shortLadder1.SetActive(false);
+            shortLadder2.SetActive(false);
+        }
+        else if (Config.deleteRailing.Value)
+        {
+            Object.Destroy(railPosts);
+            Object.Destroy(rails);
         }
     }
 }

--- a/Patches/TerminalReposition.cs
+++ b/Patches/TerminalReposition.cs
@@ -1,90 +1,72 @@
 ﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
-using BepInEx;
-using System.Runtime.CompilerServices;
-using Object = UnityEngine.Object;
-using static LethalTubeRemoval.TubeRemoval;
-using JetBrains.Annotations;
 using static LethalTubeRemoval.Config;
 
-namespace LethalTubeRemoval.Patches
+namespace LethalTubeRemoval.Patches;
+
+[HarmonyPatch(typeof(GameObject))]
+internal class TerminalReposition
 {
-    [HarmonyPatch(typeof(GameObject))]
-    internal class TerminalReposition
+    private static Terminal terminal;
+    private static ShipTeleporter teleporter = null;
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(StartOfRound), "Start")]
+    private static void TerminalMove()
     {
-        static Terminal terminal = null;
-        static ShipTeleporter teleporter = null;
-
-        [HarmonyPrefix]
-        [HarmonyPatch(typeof(StartOfRound), "Start")]
-
-        static void TerminalMove()
+        if (terminalReposition.Value)
         {
-            
-            if (Config.terminalReposition.Value)
-            {
-                GameObject terminal = GameObject.Find("Environment/HangarShip/Terminal");
-                AutoParentToShip Term = terminal.GetComponent<AutoParentToShip>();                  //gets the AutoParentToShip component for the terminal where positioning is set
+            var terminal = GameObject.Find("Environment/HangarShip/Terminal");
+            var Term = terminal
+                .GetComponent<
+                    AutoParentToShip>(); //gets the AutoParentToShip component for the terminal where positioning is set
 
-                UnityEngine.Vector3 localTerminalPos = new Vector3(9.1888f, 0.971f, -4.4357f);      //sets coords for the terminal on startup
-                UnityEngine.Vector3 terminalRotation = new Vector3(270f, 359.8239f, 0f);            //sets the rotation of the terminal
-                
-                Term.positionOffset = localTerminalPos;
-                Term.rotationOffset = terminalRotation;                                             //sets the offsets to our defined coordinates
-            }
+            var localTerminalPos = new Vector3(9.1888f, 0.971f, -4.4357f); //sets coords for the terminal on startup
+            var terminalRotation = new Vector3(270f, 359.8239f, 0f); //sets the rotation of the terminal
+
+            Term.positionOffset = localTerminalPos;
+            Term.rotationOffset = terminalRotation; //sets the offsets to our defined coordinates
         }
+    }
 
-        [HarmonyPrefix]
-        [HarmonyPatch(typeof(StartOfRound), "Update")]
-        static void TerminalMoveCustom()
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(StartOfRound), "Update")]
+    private static void TerminalMoveCustom()
+    {
+        if (customTerminal.Value)
         {
-            if (Config.customTerminal.Value)
-            {
-                GameObject terminal = GameObject.Find("Environment/HangarShip/Terminal");
-                AutoParentToShip Term = terminal.GetComponent<AutoParentToShip>();
+            var terminal = GameObject.Find("Environment/HangarShip/Terminal");
+            var Term = terminal.GetComponent<AutoParentToShip>();
 
-                UnityEngine.Vector3 localTerminalPos = new Vector3(xCordTerm.Value, yCordTerm.Value, zCordTerm.Value);
-                UnityEngine.Vector3 terminalRotation = new Vector3(xRotTerm.Value, yRotTerm.Value, zRotTerm.Value);
+            var localTerminalPos = new Vector3(xCordTerm.Value, yCordTerm.Value, zCordTerm.Value);
+            var terminalRotation = new Vector3(xRotTerm.Value, yRotTerm.Value, zRotTerm.Value);
 
-                Term.positionOffset = localTerminalPos;
-                Term.rotationOffset = terminalRotation;
-            }
+            Term.positionOffset = localTerminalPos;
+            Term.rotationOffset = terminalRotation;
         }
+    }
 
-        [HarmonyPatch(typeof(Terminal), "Start")]
-        [HarmonyPostfix]
-        static void TerminalLightStart(Terminal __instance)
-        {
-            terminal = __instance;
-            if(Config.lowLightMode.Value)
-            {
-                terminal.terminalLight.enabled = true;
-            }
-        }
+    [HarmonyPatch(typeof(Terminal), "Start")]
+    [HarmonyPostfix]
+    private static void TerminalLightStart(Terminal __instance)
+    {
+        terminal = __instance;
+        if (lowLightMode.Value) terminal.terminalLight.enabled = true;
+    }
 
-        [HarmonyPatch(typeof(Terminal), "SetTerminalInUseClientRpc")]
-        [HarmonyPostfix]
-        static void TerminalLight(Terminal __instance)
-        {
-            terminal = __instance;
-            if (Config.lowLightMode.Value)
-            {
-                terminal.terminalLight.enabled = true;
-            }
-        }
+    [HarmonyPatch(typeof(Terminal), "SetTerminalInUseClientRpc")]
+    [HarmonyPostfix]
+    private static void TerminalLight(Terminal __instance)
+    {
+        terminal = __instance;
+        if (lowLightMode.Value) terminal.terminalLight.enabled = true;
+    }
 
 
-        //Custom Terminal Coords
-        [HarmonyPostfix]
-        [HarmonyPatch(typeof(StartOfRound), "Update")]
-        public static void CustomTerminalMove()
-        {
-            
-        }
+    //Custom Terminal Coords
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(StartOfRound), "Update")]
+    public static void CustomTerminalMove()
+    {
     }
 }

--- a/Patches/TubeRemovalPatch.cs
+++ b/Patches/TubeRemovalPatch.cs
@@ -1,257 +1,204 @@
 ﻿using HarmonyLib;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
-using BepInEx;
-using System.Runtime.CompilerServices;
 using Object = UnityEngine.Object;
-using static LethalTubeRemoval.TubeRemoval;
 using static LethalTubeRemoval.Config;
 
-namespace LethalTubeRemoval.Patches
+namespace LethalTubeRemoval.Patches;
+
+[HarmonyPatch(typeof(GameObject))]
+internal class TubeRemovalPatch
 {
-    [HarmonyPatch(typeof(GameObject))]
-    internal class TubeRemovalPatch
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(StartOfRound), "Start")] //runs the patch each time the round is started
+    public static void TubeRemove()
     {
-        [HarmonyPostfix]
-        [HarmonyPatch(typeof(StartOfRound), "Start")]           //runs the patch each time the round is started
-        public static void TubeRemove()
+        var tube = GameObject.Find("Environment/HangarShip/BezierCurve"); //sets each ship item path as a GameObject
+        var beds = GameObject.Find("Environment/HangarShip/Bunkbeds");
+        var cabinet = GameObject.Find("Environment/HangarShip/FileCabinet");
+        var tank = GameObject.Find("Environment/HangarShip/ScavengerModelSuitParts/Circle.002");
+
+        var clipboard = GameObject.Find("Environment/HangarShip/ClipboardManual");
+        var doorGenerator = GameObject.Find("Environment/HangarShip/DoorGenerator");
+        var boots = GameObject.Find("Environment/HangarShip/ScavengerModelSuitParts/Circle.004");
+        var mask = GameObject.Find("Environment/HangarShip/ScavengerModelSuitParts/Circle.001");
+        var airFilter = GameObject.Find("Environment/HangarShip/ShipModels2b/AirFilterThing");
+        var stickyNote = GameObject.Find("Environment/HangarShip/StickyNoteItem");
+        var vent = GameObject.Find("Environment/HangarShip/VentEntrance/Hinge");
+
+        var battery = GameObject.Find("Environment/HangarShip/SmallDetails/BatterySingle");
+        var battery1 = GameObject.Find("Environment/HangarShip/SmallDetails/BatterySingle (1)");
+        var battery2 = GameObject.Find("Environment/HangarShip/SmallDetails/BatterySingle (2)");
+        var batteryPack = GameObject.Find("Environment/HangarShip/SmallDetails/BatteryPack");
+
+        var monitorCords = GameObject.Find("Environment/HangarShip/WallCords");
+        var doorSpeaker = GameObject.Find("Environment/HangarShip/ShipModels2b/Cube.005 (1)");
+        var posters = GameObject.Find("Environment/HangarShip/Plane.001");
+        var clothingRack = GameObject.Find("Environment/HangarShip/NurbsPath.004");
+        var clothingHook = GameObject.Find("Environment/HangarShip/NurbsPath.002");
+        var defaultSuit = GameObject.Find("ChangableSuit(Clone)");
+        var doorTubes = GameObject.Find("Environment/HangarShip/NurbsPath");
+        var keyboardCord = GameObject.Find("Environment/HangarShip/Terminal/BezierCurve.001");
+
+        var mainSpeaker = GameObject.Find("Environment/HangarShip/ShipModels2b/Cube.005 (2)");
+        var speakerAudio = GameObject.Find("Environment/HangarShip/ShipModels2b/Cube.005 (2)/SpeakerAudio");
+
+
+        //Lights
+        var areaLight1 = GameObject.Find("Environment/HangarShip/ShipElectricLights/Area Light (3)");
+        var areaLight2 = GameObject.Find("Environment/HangarShip/ShipElectricLights/Area Light (4)");
+        var areaLight3 = GameObject.Find("Environment/HangarShip/ShipElectricLights/Area Light (5)");
+        var hangingLamp1 = GameObject.Find("Environment/HangarShip/ShipElectricLights/HangingLamp (2)");
+        var hangingLamp3 = GameObject.Find("Environment/HangarShip/ShipElectricLights/HangingLamp (4)");
+
+        //Store Items
+
+
+        if (deleteTube.Value) //checks config file for boolean value and if true deletes the item
+            Object.Destroy(tube);
+
+        if (deleteBunkbeds.Value) Object.Destroy(beds);
+
+        if (deleteFileCabinets.Value) Object.Destroy(cabinet);
+
+        if (deleteOxygenTank.Value) Object.Destroy(tank);
+
+        if (deleteClipboard.Value) Object.Destroy(clipboard);
+
+        if (deleteDoorGenerator.Value) Object.Destroy(doorGenerator);
+
+        if (deleteBoots.Value) Object.Destroy(boots);
+
+        if (deleteMask.Value) Object.Destroy(mask);
+
+        if (deleteAirFilter.Value) Object.Destroy(airFilter);
+
+        if (deleteStickyNote.Value) Object.Destroy(stickyNote);
+
+        if (deleteBatteries.Value)
         {
-            GameObject tube = GameObject.Find("Environment/HangarShip/BezierCurve");        //sets each ship item path as a GameObject
-            GameObject beds = GameObject.Find("Environment/HangarShip/Bunkbeds");
-            GameObject cabinet = GameObject.Find("Environment/HangarShip/FileCabinet");
-            GameObject tank = GameObject.Find("Environment/HangarShip/ScavengerModelSuitParts/Circle.002");
-
-            GameObject clipboard = GameObject.Find("Environment/HangarShip/ClipboardManual");
-            GameObject doorGenerator = GameObject.Find("Environment/HangarShip/DoorGenerator");
-            GameObject boots = GameObject.Find("Environment/HangarShip/ScavengerModelSuitParts/Circle.004");
-            GameObject mask = GameObject.Find("Environment/HangarShip/ScavengerModelSuitParts/Circle.001");
-            GameObject airFilter = GameObject.Find("Environment/HangarShip/ShipModels2b/AirFilterThing");
-            GameObject stickyNote = GameObject.Find("Environment/HangarShip/StickyNoteItem");
-            GameObject vent = GameObject.Find("Environment/HangarShip/VentEntrance/Hinge");
-
-            GameObject battery = GameObject.Find("Environment/HangarShip/SmallDetails/BatterySingle");
-            GameObject battery1 = GameObject.Find("Environment/HangarShip/SmallDetails/BatterySingle (1)");
-            GameObject battery2 = GameObject.Find("Environment/HangarShip/SmallDetails/BatterySingle (2)");
-            GameObject batteryPack = GameObject.Find("Environment/HangarShip/SmallDetails/BatteryPack");
-
-            GameObject monitorCords = GameObject.Find("Environment/HangarShip/WallCords");
-            GameObject doorSpeaker = GameObject.Find("Environment/HangarShip/ShipModels2b/Cube.005 (1)");
-            GameObject posters = GameObject.Find("Environment/HangarShip/Plane.001");
-            GameObject clothingRack = GameObject.Find("Environment/HangarShip/NurbsPath.004");
-            GameObject clothingHook = GameObject.Find("Environment/HangarShip/NurbsPath.002");
-            GameObject defaultSuit = GameObject.Find("ChangableSuit(Clone)");
-            GameObject doorTubes = GameObject.Find("Environment/HangarShip/NurbsPath");
-            GameObject keyboardCord = GameObject.Find("Environment/HangarShip/Terminal/BezierCurve.001");
-
-            GameObject mainSpeaker = GameObject.Find("Environment/HangarShip/ShipModels2b/Cube.005 (2)");
-            GameObject speakerAudio = GameObject.Find("Environment/HangarShip/ShipModels2b/Cube.005 (2)/SpeakerAudio");
-
-
-            //Lights
-            GameObject areaLight1 = GameObject.Find("Environment/HangarShip/ShipElectricLights/Area Light (3)");
-            GameObject areaLight2 = GameObject.Find("Environment/HangarShip/ShipElectricLights/Area Light (4)");
-            GameObject areaLight3 = GameObject.Find("Environment/HangarShip/ShipElectricLights/Area Light (5)");
-            GameObject hangingLamp1 = GameObject.Find("Environment/HangarShip/ShipElectricLights/HangingLamp (2)");
-            GameObject hangingLamp3 = GameObject.Find("Environment/HangarShip/ShipElectricLights/HangingLamp (4)");
-
-            //Store Items
-
-
-            if (Config.deleteTube.Value)            //checks config file for boolean value and if true deletes the item
-            {
-                GameObject.Destroy(tube);
-            }
-
-            if (Config.deleteBunkbeds.Value)
-            {
-                GameObject.Destroy(beds);
-            }
-
-            if (Config.deleteFileCabinets.Value)
-            {
-                GameObject.Destroy(cabinet);
-            }
-
-            if (Config.deleteOxygenTank.Value)
-            {
-                GameObject.Destroy(tank);
-            }
-
-            if (Config.deleteClipboard.Value)
-            {
-                GameObject.Destroy(clipboard);
-            }
-
-            if (Config.deleteDoorGenerator.Value)
-            {
-                GameObject.Destroy(doorGenerator);
-            }
-
-            if (Config.deleteBoots.Value)
-            {
-                GameObject.Destroy(boots);
-            }
-
-            if (Config.deleteMask.Value)
-            {
-                GameObject.Destroy(mask);
-            }
-
-            if (Config.deleteAirFilter.Value)
-            {
-                GameObject.Destroy(airFilter);
-            }
-
-            if (Config.deleteStickyNote.Value)
-            {
-                GameObject.Destroy(stickyNote);
-            }
-
-            if (Config.deleteBatteries.Value)
-            {
-                GameObject.Destroy(battery);
-                GameObject.Destroy(battery1);
-                GameObject.Destroy(battery2);
-                GameObject.Destroy(batteryPack);
-            }
-
-            if (Config.deleteVent.Value)
-            {
-                GameObject.Destroy(vent);
-            }
-
-            if (Config.deleteMonitorCords.Value)
-            {
-                GameObject.Destroy(monitorCords);
-            }
-
-            if (Config.deleteDoorSpeaker.Value)
-            {
-                GameObject.Destroy(doorSpeaker);
-            }
-
-            if (Config.deleteMainSpeaker.Value)
-            {
-                //ship speaker being instantiated is somehow tied to the ship door manual controls
-                //to work around this I hid the speaker inside the ship wall and disabled the audio
-                UnityEngine.Vector3 localSpeakerPos = new Vector3(11.4571f, 1.9706f, -16.9578f);        //hides the speaker in the front of the ship in the wall behind the monitors
-                mainSpeaker.transform.position = localSpeakerPos;
-                GameObject.Destroy(speakerAudio);                                                       //disables the audio from the speaker
-            }
-
-            if (Config.deletePosters.Value)
-            {
-                GameObject.Destroy(posters);
-            }
-
-            if (Config.deleteClothingRack.Value)
-            {
-                GameObject.Destroy(clothingRack);
-                GameObject.Destroy(clothingHook);
-                GameObject.Destroy(defaultSuit);
-            }
-
-            if (Config.deleteDoorTubes.Value)
-            {
-                GameObject.Destroy(doorTubes);
-            }
-
-            if (Config.deleteKeyboardCord.Value)
-            {
-                GameObject.Destroy(keyboardCord);
-            }
-
-            if (Config.lowLightMode.Value)
-            {
-                GameObject.Destroy(areaLight1);
-                GameObject.Destroy(areaLight2);
-                GameObject.Destroy(areaLight3);
-                GameObject.Destroy(hangingLamp1);
-                GameObject.Destroy(hangingLamp3);
-            }
+            Object.Destroy(battery);
+            Object.Destroy(battery1);
+            Object.Destroy(battery2);
+            Object.Destroy(batteryPack);
         }
 
-        [HarmonyPostfix]
-        [HarmonyPatch(typeof(StartOfRound), "Update")]
-        public static void CustomCoords()
-        {
-            //for custom charging coil coordinates
-            if (Config.moveCoil.Value)
-            {
-                GameObject chargingCoil = GameObject.Find("Environment/HangarShip/ShipModels2b/ChargeStation");
-                UnityEngine.Vector3 chargeLocalPos = new Vector3(xCordCoil.Value, yCordCoil.Value, zCordCoil.Value);
-                UnityEngine.Vector3 chargeLocalRotation = new Vector3(xRotCoil.Value, yRotCoil.Value, zRotCoil.Value);
+        if (deleteVent.Value) Object.Destroy(vent);
 
-                chargingCoil.transform.localPosition = chargeLocalPos;
-                chargingCoil.transform.eulerAngles = chargeLocalRotation;
-            }
+        if (deleteMonitorCords.Value) Object.Destroy(monitorCords);
+
+        if (deleteDoorSpeaker.Value) Object.Destroy(doorSpeaker);
+
+        if (deleteMainSpeaker.Value)
+        {
+            //ship speaker being instantiated is somehow tied to the ship door manual controls
+            //to work around this I hid the speaker inside the ship wall and disabled the audio
+            var localSpeakerPos =
+                new Vector3(11.4571f, 1.9706f,
+                    -16.9578f); //hides the speaker in the front of the ship in the wall behind the monitors
+            mainSpeaker.transform.position = localSpeakerPos;
+            Object.Destroy(speakerAudio); //disables the audio from the speaker
         }
 
-        [HarmonyPostfix]
-        [HarmonyPatch(typeof(ShipTeleporter), "Awake")]
-        static void TeleporterCord()
+        if (deletePosters.Value) Object.Destroy(posters);
+
+        if (deleteClothingRack.Value)
         {
-            if (GameObject.Find("Teleporter(Clone)/ButtonContainer/LongCord"))
-            {
-                GameObject longCord = GameObject.Find("Teleporter(Clone)/ButtonContainer/LongCord");
-                longCord.SetActive(false);
-            }
+            Object.Destroy(clothingRack);
+            Object.Destroy(clothingHook);
+            Object.Destroy(defaultSuit);
         }
 
-        [HarmonyPostfix]
-        [HarmonyPatch(typeof(ShipTeleporter), "Awake")]
-        public static void TeleporterButtons()
+        if (deleteDoorTubes.Value) Object.Destroy(doorTubes);
+
+        if (deleteKeyboardCord.Value) Object.Destroy(keyboardCord);
+
+        if (lowLightMode.Value)
         {
-            if (Config.moveTeleButtonsToDesk.Value && GameObject.Find("Teleporter(Clone)/ButtonContainer"))
+            Object.Destroy(areaLight1);
+            Object.Destroy(areaLight2);
+            Object.Destroy(areaLight3);
+            Object.Destroy(hangingLamp1);
+            Object.Destroy(hangingLamp3);
+        }
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(StartOfRound), "Update")]
+    public static void CustomCoords()
+    {
+        //for custom charging coil coordinates
+        if (moveCoil.Value)
+        {
+            var chargingCoil = GameObject.Find("Environment/HangarShip/ShipModels2b/ChargeStation");
+            var chargeLocalPos = new Vector3(xCordCoil.Value, yCordCoil.Value, zCordCoil.Value);
+            var chargeLocalRotation = new Vector3(xRotCoil.Value, yRotCoil.Value, zRotCoil.Value);
+
+            chargingCoil.transform.localPosition = chargeLocalPos;
+            chargingCoil.transform.eulerAngles = chargeLocalRotation;
+        }
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(ShipTeleporter), "Awake")]
+    private static void TeleporterCord()
+    {
+        if (GameObject.Find("Teleporter(Clone)/ButtonContainer/LongCord"))
+        {
+            var longCord = GameObject.Find("Teleporter(Clone)/ButtonContainer/LongCord");
+            longCord.SetActive(false);
+        }
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(ShipTeleporter), "Awake")]
+    public static void TeleporterButtons()
+    {
+        if (moveTeleButtonsToDesk.Value && GameObject.Find("Teleporter(Clone)/ButtonContainer"))
+        {
+            [HarmonyPostfix]
+            [HarmonyPatch(typeof(ShipTeleporter), "Update")]
+            static void TeleporterStuff()
             {
-                [HarmonyPostfix]
-                [HarmonyPatch(typeof(ShipTeleporter), "Update")]
-                static void TeleporterStuff()
+                if (moveTeleButtonsToDesk.Value)
                 {
-                    if (Config.moveTeleButtonsToDesk.Value)
-                    {
-                        GameObject teleButton = GameObject.Find("Teleporter(Clone)/ButtonContainer");
-                        UnityEngine.Vector3 teleButtonGlobal = new Vector3(1.8872f, -1.4394f, -11.642f);
-                        UnityEngine.Vector3 teleButtonPosLocal = new Vector3(-1.1767f, -3.1688f, 2.2629f);
+                    var teleButton = GameObject.Find("Teleporter(Clone)/ButtonContainer");
+                    var teleButtonGlobal = new Vector3(1.8872f, -1.4394f, -11.642f);
+                    var teleButtonPosLocal = new Vector3(-1.1767f, -3.1688f, 2.2629f);
 
-                          
-                        teleButton.transform.localRotation = new UnityEngine.Quaternion(0.1211f, -0.1197f, -0.0436f, -0.9844f);       //to get this quaternion, use UnityExplorer, find the buttoncontainer rotation vector you need
-                        teleButton.transform.position = teleButtonGlobal;
-                        teleButton.transform.localPosition = teleButtonPosLocal;
-                    }
+
+                    teleButton.transform.localRotation =
+                        new Quaternion(0.1211f, -0.1197f, -0.0436f,
+                            -0.9844f); //to get this quaternion, use UnityExplorer, find the buttoncontainer rotation vector you need
+                    teleButton.transform.position = teleButtonGlobal;
+                    teleButton.transform.localPosition = teleButtonPosLocal;
                 }
             }
         }
+    }
 
-        [HarmonyPostfix]
-        [HarmonyPatch(typeof(ShipTeleporter), "Awake")]
-        public static void InverseTeleporterButtons()
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(ShipTeleporter), "Awake")]
+    public static void InverseTeleporterButtons()
+    {
+        if (moveTeleButtonsToDesk.Value && GameObject.Find("InverseTeleporter(Clone)/ButtonContainer"))
         {
-            if (Config.moveTeleButtonsToDesk.Value && GameObject.Find("InverseTeleporter(Clone)/ButtonContainer"))
+            [HarmonyPostfix]
+            [HarmonyPatch(typeof(ShipTeleporter), "Update")]
+            static void InverseTeleporterStuff()
             {
-                [HarmonyPostfix]
-                [HarmonyPatch(typeof(ShipTeleporter), "Update")]
-                static void InverseTeleporterStuff()
+                if (moveTeleButtonsToDesk.Value)
                 {
-                    if (Config.moveTeleButtonsToDesk.Value)
-                    {
-                        GameObject inverseTeleButton = GameObject.Find("InverseTeleporter(Clone)/ButtonContainer");
+                    var inverseTeleButton = GameObject.Find("InverseTeleporter(Clone)/ButtonContainer");
 
-                        UnityEngine.Vector3 inverseTeleButtonPosGlobal = new Vector3(1.21f, 0.74f, -14.12f);
-                        UnityEngine.Vector3 inverseTeleButtonPosLocal = new Vector3(0.2214f, 0.3496f, 0.3927f);
-                        UnityEngine.Vector3 teleButtonGlobal = new Vector3(1.8872f, -1.4394f, -11.642f);
+                    var inverseTeleButtonPosGlobal = new Vector3(1.21f, 0.74f, -14.12f);
+                    var inverseTeleButtonPosLocal = new Vector3(0.2214f, 0.3496f, 0.3927f);
+                    var teleButtonGlobal = new Vector3(1.8872f, -1.4394f, -11.642f);
 
-                        inverseTeleButton.transform.localRotation = new UnityEngine.Quaternion(0f, 0.0175f, 0f, 0.9998f);
-                        inverseTeleButton.transform.position = inverseTeleButtonPosGlobal;
-                        inverseTeleButton.transform.localPosition = inverseTeleButtonPosLocal;
-                    }
+                    inverseTeleButton.transform.localRotation = new Quaternion(0f, 0.0175f, 0f, 0.9998f);
+                    inverseTeleButton.transform.position = inverseTeleButtonPosGlobal;
+                    inverseTeleButton.transform.localPosition = inverseTeleButtonPosLocal;
                 }
             }
         }
     }
 }
-

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,53 +1,38 @@
 ﻿using BepInEx;
-using BepInEx.Configuration;
 using BepInEx.Logging;
 using HarmonyLib;
-using LethalConfig.ConfigItems;
-using LethalConfig;
 using LethalTubeRemoval.Patches;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
-using System.Security.Policy;
 
-namespace LethalTubeRemoval
+namespace LethalTubeRemoval;
+
+[BepInPlugin(modGUID, modName, modVersion)]
+[BepInDependency("ainavt.lc.lethalconfig")]
+public class TubeRemoval : BaseUnityPlugin
 {
-    [BepInPlugin(modGUID, modName, modVersion)]
-    [BepInDependency("ainavt.lc.lethalconfig")]
-    public class TubeRemoval : BaseUnityPlugin
+    private const string modGUID = "Hamster.LethalTubeRemoval";
+    private const string modName = "Lethal Tube Removal";
+    private const string modVersion = "1.6.1";
+
+    private static TubeRemoval? Instance;
+
+    private readonly Harmony harmony = new(modGUID);
+
+    internal ManualLogSource mls;
+
+    public static Config MyConfig { get; internal set; }
+
+    private void Awake()
     {
-        private const string modGUID = "Hamster.LethalTubeRemoval";
-        private const string modName = "Lethal Tube Removal";
-        private const string modVersion = "1.6.1";
+        Instance ??= this;
 
-        public static new Config MyConfig { get; internal set; }
+        mls = BepInEx.Logging.Logger.CreateLogSource(modGUID);
+        mls.LogInfo("Mod is woked");
 
-        private readonly Harmony harmony = new Harmony(modGUID);
+        MyConfig = new Config(Config);
 
-        private static TubeRemoval Instance;
-
-        internal ManualLogSource mls;
-
-        void Awake()
-        {
-            if (Instance = null)
-            {
-                Instance = this;
-            }
-
-            mls = BepInEx.Logging.Logger.CreateLogSource(modGUID);
-            mls.LogInfo("Mod is woked");
-
-            MyConfig = new(base.Config);
-
-            harmony.PatchAll(typeof(TubeRemoval));
-            harmony.PatchAll(typeof(TubeRemovalPatch));
-            harmony.PatchAll(typeof(TerminalReposition));
-            harmony.PatchAll(typeof(OutsideShipPatch));
-        }
+        harmony.PatchAll(typeof(TubeRemoval));
+        harmony.PatchAll(typeof(TubeRemovalPatch));
+        harmony.PatchAll(typeof(TerminalReposition));
+        harmony.PatchAll(typeof(OutsideShipPatch));
     }
-
 }


### PR DESCRIPTION
This mod seemed to be incompatible with LethalModDataLib. Not sure if it was due to some of the redundant using statements, but I fixed those for you. I also applied Rider's cleanup to the project, and did some manual touch ups here and there. Finally, I also changed your .csproj to use NuGet packages instead of local references, for BepInEx and UnityEngine.