### PR TITLE
Null reference fix, door monitor, and unity warnings

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -428,7 +428,7 @@ public class Config
             inside,
             "Door Speaker",
             false,
-            "Deletes the speaker near the ship door"
+            "Deletes the speaker near the ship door !!WARNING: If you are reading logs, this option will spam null audio warnings in v50."
         );
         var doorSpeakerToggle = new BoolCheckBoxConfigItem(deleteDoorSpeaker, false);
         LethalConfigManager.AddConfigItem(doorSpeakerToggle);

--- a/Config.cs
+++ b/Config.cs
@@ -77,6 +77,7 @@ public class Config
     public static ConfigEntry<bool> deleteKeyboardCord;
     public static ConfigEntry<bool> terminalReposition;
     public static ConfigEntry<bool> deleteShelf;
+    public static ConfigEntry<bool> deleteDoorMonitor;
 
     //Outside Ship
     public static ConfigEntry<bool> deleteFloodLight;
@@ -485,6 +486,15 @@ public class Config
         );
         var shelfToggle = new BoolCheckBoxConfigItem(deleteShelf, false);
         LethalConfigManager.AddConfigItem(shelfToggle);
+
+        deleteDoorMonitor = cfg.Bind(
+            inside,
+            "Door Monitor",
+            false,
+            "Deletes the monitor above the door buttons"
+        );
+        var doorMonitorToggle = new BoolCheckBoxConfigItem(deleteDoorMonitor, false);
+        LethalConfigManager.AddConfigItem(doorMonitorToggle);
 
 
         // OUTSIDE SHIP

--- a/Patches/TerminalReposition.cs
+++ b/Patches/TerminalReposition.cs
@@ -61,12 +61,4 @@ internal class TerminalReposition
         terminal = __instance;
         if (lowLightMode.Value) terminal.terminalLight.enabled = true;
     }
-
-
-    //Custom Terminal Coords
-    [HarmonyPostfix]
-    [HarmonyPatch(typeof(StartOfRound), "Update")]
-    public static void CustomTerminalMove()
-    {
-    }
 }

--- a/Patches/TubeRemovalPatch.cs
+++ b/Patches/TubeRemovalPatch.cs
@@ -51,7 +51,7 @@ internal class TubeRemovalPatch
         var areaLight3 = GameObject.Find("Environment/HangarShip/ShipElectricLights/Area Light (5)");
         var hangingLamp1 = GameObject.Find("Environment/HangarShip/ShipElectricLights/HangingLamp (2)");
         var hangingLamp3 = GameObject.Find("Environment/HangarShip/ShipElectricLights/HangingLamp (4)");
-        
+
         //Store Items
         if (deleteTube.Value) //checks config file for boolean value and if true deletes the item
             Object.Destroy(tube);
@@ -88,7 +88,15 @@ internal class TubeRemovalPatch
 
         if (deleteMonitorCords.Value) Object.Destroy(monitorCords);
 
-        if (deleteDoorSpeaker.Value) Object.Destroy(doorSpeaker);
+        if (deleteDoorSpeaker.Value)
+        {
+            //door speaker was causing unity warning spam in v50 so moving it instead of deleting only causes warning on ship takeoff/land
+            var localSpeakerPos =
+                new Vector3(11.4571f, 1.9706f,
+                    -16.9578f); //hides the speaker in the front of the ship in the wall behind the monitors
+            doorSpeaker.transform.position = localSpeakerPos;
+        }
+
 
         if (deleteMainSpeaker.Value)
         {
@@ -123,7 +131,7 @@ internal class TubeRemovalPatch
             Object.Destroy(hangingLamp3);
         }
 
-        if (deleteDoorMonitor.Value) doorMonitor.SetActive(false);
+        if (deleteDoorMonitor.Value) Object.Destroy(doorMonitor);
     }
 
     [HarmonyPostfix]

--- a/Patches/TubeRemovalPatch.cs
+++ b/Patches/TubeRemovalPatch.cs
@@ -50,10 +50,8 @@ internal class TubeRemovalPatch
         var areaLight3 = GameObject.Find("Environment/HangarShip/ShipElectricLights/Area Light (5)");
         var hangingLamp1 = GameObject.Find("Environment/HangarShip/ShipElectricLights/HangingLamp (2)");
         var hangingLamp3 = GameObject.Find("Environment/HangarShip/ShipElectricLights/HangingLamp (4)");
-
+        
         //Store Items
-
-
         if (deleteTube.Value) //checks config file for boolean value and if true deletes the item
             Object.Destroy(tube);
 
@@ -184,7 +182,7 @@ internal class TubeRemovalPatch
             [HarmonyPatch(typeof(ShipTeleporter), "Update")]
             static void TeleporterStuff()
             {
-                if (moveTeleButtonsToDesk.Value)
+                if (moveTeleButtonsToDesk.Value && GameObject.Find("Teleporter(Clone)/ButtonContainer"))
                 {
                     var teleButton = GameObject.Find("Teleporter(Clone)/ButtonContainer");
                     var teleButtonGlobal = new Vector3(1.8872f, -1.4394f, -11.642f);
@@ -211,10 +209,9 @@ internal class TubeRemovalPatch
             [HarmonyPatch(typeof(ShipTeleporter), "Update")]
             static void InverseTeleporterStuff()
             {
-                if (moveTeleButtonsToDesk.Value)
+                if (moveTeleButtonsToDesk.Value && GameObject.Find("InverseTeleporter(Clone)/ButtonContainer"))
                 {
                     var inverseTeleButton = GameObject.Find("InverseTeleporter(Clone)/ButtonContainer");
-
                     var inverseTeleButtonPosGlobal = new Vector3(1.21f, 0.74f, -14.12f);
                     var inverseTeleButtonPosLocal = new Vector3(0.2214f, 0.3496f, 0.3927f);
                     var teleButtonGlobal = new Vector3(1.8872f, -1.4394f, -11.642f);
@@ -222,7 +219,7 @@ internal class TubeRemovalPatch
                     inverseTeleButton.transform.localRotation = new Quaternion(0f, 0.0175f, 0f, 0.9998f);
                     inverseTeleButton.transform.position = inverseTeleButtonPosGlobal;
                     inverseTeleButton.transform.localPosition = inverseTeleButtonPosLocal;
-                }
+                    }
             }
         }
     }

--- a/Patches/TubeRemovalPatch.cs
+++ b/Patches/TubeRemovalPatch.cs
@@ -42,6 +42,7 @@ internal class TubeRemovalPatch
 
         var mainSpeaker = GameObject.Find("Environment/HangarShip/ShipModels2b/Cube.005 (2)");
         var speakerAudio = GameObject.Find("Environment/HangarShip/ShipModels2b/Cube.005 (2)/SpeakerAudio");
+        var doorMonitor = GameObject.Find("Environment/HangarShip/ShipModels2b/MonitorWall/SingleScreen");
 
 
         //Lights
@@ -121,6 +122,8 @@ internal class TubeRemovalPatch
             Object.Destroy(hangingLamp1);
             Object.Destroy(hangingLamp3);
         }
+
+        if (deleteDoorMonitor.Value) doorMonitor.SetActive(false);
     }
 
     [HarmonyPostfix]


### PR DESCRIPTION
First good patch in awhile. Did the following:

1.  Added another check that fixes the attempt to grab the teleporter object before it has been purchased to move the buttons, fixing the null reference error that was being spammed. #28 

2. Added the option to remove the monitor above the door buttons that displays the outside security camera. #27 

3. Made some minor changes to attempt to address some of the logging issues. v50 has introduced a litany of Unity warnings that were not being printed before, which greatly clutters the log. I have cut back on most of them, but one option in particular is still an issue. If you are not a developer or someone interested in logs it should not make much of a difference to you, but the "Remove Door Speaker" option, will cause unity sound warnings to be printed throughout your time on a moon. Most other warnings are all printed while in space and only printed once.